### PR TITLE
fix: Add `expression` object to all EIPs which supports expression (#…

### DIFF
--- a/delay.camel-component.yaml
+++ b/delay.camel-component.yaml
@@ -13,8 +13,6 @@ spec:
   definition:
     title: "Delay"
     description: "The Claim Check from the EIP patterns allows you to replace message content with a claim check (a unique key), which can be used to retrieve the message content at a later time."
-    required:
-      - expression
     type: object
     properties:
       expression:

--- a/dynamic-router.camel-component.yaml
+++ b/dynamic-router.camel-component.yaml
@@ -12,8 +12,6 @@ spec:
   definition:
     title: "Dynamic Router"
     description: "The Dynamic Router from the EIP patterns allows you to route messages while avoiding the dependency of the router on all possible destinations while maintaining its efficiency."
-    required:
-      - expression
     properties:
       expression:
         title: Expression 

--- a/enrich.camel-component.yaml
+++ b/enrich.camel-component.yaml
@@ -11,8 +11,6 @@ spec:
   definition:
     title: "Content Enricher"
     description: "Content Enricher from the EIP patterns."
-    required:
-      - expression
     properties:
       expression:
         title: Expression 

--- a/filter.camel-component.yaml
+++ b/filter.camel-component.yaml
@@ -15,11 +15,15 @@ spec:
     title: "Filter"
     description: "The Message Filter from the EIP patterns allows you to filter messages. The message filter implemented in Camel is similar to if (predicate) { block } in Java. The filter will include the message if the predicate evaluated to true."
     properties:
+      expression:
+        title: Expression
+        description: Expression content of the filter.
+        type: object
       simple:
-        description: Simple language content of the body to set.
+        description: Simple language content of the filter.
         type: string
         example: 'Body: ${body}'
       jq:
-        description: Jq language content of the body to set.
+        description: Jq language content of the filter.
         type: string
         example: '.foo == "baz"'

--- a/idempotent-consumer.camel-component.yaml
+++ b/idempotent-consumer.camel-component.yaml
@@ -15,8 +15,6 @@ spec:
   definition:
     title: "Idempotent Consumer"
     description: "The Idempotent Consumer from the EIP patterns is used to filter out duplicate messages. The Idempotent Consumer essentially acts like a Message Filter to filter out duplicates."
-    required:
-      - expression
     properties:
       expression:
         title: Expression

--- a/loop.camel-component.yaml
+++ b/loop.camel-component.yaml
@@ -15,8 +15,6 @@ spec:
   definition:
     title: "Loop"
     description: "The Loop EIP allows for processing a message a number of times, possibly in a different way for each iteration."
-    required:
-      - expression
     properties:
       expression:
         title: Expression

--- a/message-router-choice.camel-component.yaml
+++ b/message-router-choice.camel-component.yaml
@@ -17,6 +17,10 @@ spec:
     description: "The Content Based Router from the EIP patterns allows you to route messages to the correct destination based on the contents of the message exchanges. Message Router: Choice"
     required:
     properties:
+      expression:
+        title: Expression
+        description: Conditional to apply to go through this branch
+        type: object
       simple:
         title: Conditional in Simple form
         description: Conditional to apply to go through this branch

--- a/poll-enrich.camel-component.yaml
+++ b/poll-enrich.camel-component.yaml
@@ -12,8 +12,6 @@ spec:
   definition:
     title: "Poll Content Enricher"
     description: "Content Enricher from the EIP patterns."
-    required:
-      - expression
     properties:
       expression:
         title: Expression 

--- a/recipient-list.camel-component.yaml
+++ b/recipient-list.camel-component.yaml
@@ -12,8 +12,6 @@ spec:
   definition:
     title: "Recipient List"
     description: "Define a channel for each recipient. Then use a Recipient List to inspect an incoming message, determine the list of desired recipients, and forward the message to all channels associated with the recipients in the list."
-    required:
-      - expression
     properties:
       expression:
         title: Expression 

--- a/resequence.camel-component.yaml
+++ b/resequence.camel-component.yaml
@@ -14,8 +14,6 @@ spec:
   definition:
     title: "Resequence"
     description: "Use a stateful filter, a Resequencer, to collect and re-order messages so that they can be published to the output channel in a specified order."
-    required:
-      - expression
     type: object
     properties:
       expression:

--- a/routing-slip.camel-component.yaml
+++ b/routing-slip.camel-component.yaml
@@ -14,8 +14,6 @@ spec:
   definition:
     title: "Routing Slip"
     description: "Attach a Routing Slip to each message, specifying the sequence of processing steps. Wrap each component with a special message router that reads the Routing Slip and routes the message to the next component in the list."
-    required:
-      - expression
     type: object
     properties:
       expression:

--- a/script.camel-component.yaml
+++ b/script.camel-component.yaml
@@ -16,11 +16,15 @@ spec:
     title: "Script"
     description: "The Script EIP is used for executing a coding script. This is useful when you need to invoke some logic that are not in Java code such as JavaScript, Groovy or any of the other Languages. 	The returned value from the script is discarded and not used. If the returned value should be set as the new message body, then use the Message Translator EIP instead."
     properties:
+      expression:
+        title: Expression
+        description: Expression content of the script.
+        type: object
       groovy:
-        description: Groovy language content of the body to set.
+        description: Groovy language content of the script.
         type: string
         example: 'println "Hello World"'
       javascript:
-        description: JavaScript language content of the body to set.
+        description: JavaScript language content of the script.
         type: string
         example: 'var util = require("util"); util.log("Hello World");'

--- a/set-body.camel-component.yaml
+++ b/set-body.camel-component.yaml
@@ -14,6 +14,10 @@ spec:
     title: "Set Body"
     description: "Transform the body of the message following the Message Translator EIP using en expression in simple language (Apache Camel)."
     properties:
+      expression:
+        title: Expression
+        description: Expression content of the body to set.
+        type: object
       simple:
         title: Simple 
         description: Simple language content of the body to set.

--- a/set-header.camel-component.yaml
+++ b/set-header.camel-component.yaml
@@ -15,6 +15,10 @@ spec:
     required:
       - name
     properties:
+      expression:
+        title: Expression
+        description: "Expression to set the header to."
+        type: object
       name:
         title: Name of the Header
         description: "Which header are we going to set."

--- a/set-property.camel-component.yaml
+++ b/set-property.camel-component.yaml
@@ -15,6 +15,10 @@ spec:
     required:
       - name
     properties:
+      expression:
+        title: Expression
+        description: "Expression to set the property to."
+        type: object
       name:
         title: Name of the Property
         description: "Which property are we going to set."
@@ -25,13 +29,13 @@ spec:
         type: object
       simple:
         title: Simple
-        description: "Value in simple form to set the header to."
+        description: "Value in simple form to set the property to."
         type: string
       constant:
         title: Constant
-        description: "Constant value to set the header to."
+        description: "Constant value to set the property to."
         type: string
       jq:
         title: Jq
-        description: "Jq expression to set the header to."
+        description: "Jq expression to set the property to."
         type: string

--- a/transform.camel-component.yaml
+++ b/transform.camel-component.yaml
@@ -13,6 +13,10 @@ spec:
     title: "Transform"
     description: "Transform the body of the message following the Message Translator EIP using en expression in simple language (Apache Camel)."
     properties:
+      expression:
+        title: Expression
+        description: Expression content of the body to set.
+        type: object
       simple:
         description: Simple language content of the body to set.
         type: string


### PR DESCRIPTION
…548)

But remove from `required` as it could be also configured from other properties (constant, simple, jq)